### PR TITLE
Derive quiz identifiers from module id

### DIFF
--- a/examlab_v1_1.py
+++ b/examlab_v1_1.py
@@ -367,8 +367,13 @@ def build_quiz_activity_xml(
     question_infos: List[Dict[str, Any]] | None = None,
     per_slot_maxmark: float = 1.0,
 ) -> bytes:
-    activity_id = 260000
-    quiz_id = 260000
+    # Derive stable identifiers from the supplied moduleid so that each
+    # exported quiz receives unique values instead of the previous fixed
+    # placeholder. Multiplying by 10 keeps the identifiers in the same
+    # numeric range while avoiding collisions when multiple module IDs are
+    # sequential (e.g., moduleid=100, 101, ...).
+    activity_id = moduleid * 10
+    quiz_id = activity_id + 1
 
     root = ET.Element(
         "activity",


### PR DESCRIPTION
## Summary
- derive quiz activity and quiz identifiers from the provided module id to avoid fixed values
- ensure the generated activity and quiz XML embed the new unique identifiers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68f7fc90d618832da45675187b7ab7ee